### PR TITLE
Update scripts to be compatible with new atomic data file structure

### DIFF
--- a/tardis_minimal_model.py
+++ b/tardis_minimal_model.py
@@ -230,7 +230,9 @@ class minimal_model(object):
         """
 
         self.time_of_simulation = simulation.runner.time_of_simulation
-        self.lines = simulation.plasma.atomic_data.lines
+        self.lines = \
+            simulation.plasma.atomic_data.lines.reset_index().set_index(
+                'line_id')
         self.R_phot = (simulation.model._velocity[0] *
                        simulation.model.time_explosion).to("cm")
         self.t_inner = simulation.model.t_inner
@@ -296,7 +298,8 @@ class minimal_model(object):
 
         self.time_of_simulation = \
             hdf_store["/configuration"].time_of_simulation
-        self.lines = hdf_store["/atom_data/lines"]
+        self.lines = hdf_store["/atom_data/lines"].reset_index().set_index(
+            'line_id')
         self.R_phot = hdf_store["/configuration"].R_photosphere
         self.t_inner = hdf_store["/configuration"].t_inner
 

--- a/tardis_opacity.py
+++ b/tardis_opacity.py
@@ -188,28 +188,28 @@ class opacity_calculator(object):
     def nshells(self):
         """number of radial shells in the model"""
         if self._nshells is None:
-            self._nshells = self.mdl.tardis_config["structure"]["no_of_shells"]
+            self._nshells = self.mdl.model.no_of_shells
         return self._nshells
 
     @property
     def t_exp(self):
         """time since explosion of the model"""
         if self._t_exp is None:
-            self._t_exp = self.mdl.tardis_config['supernova']['time_explosion']
+            self._t_exp = self.mdl.model.time_explosion
         return self._t_exp
 
     @property
     def r_inner(self):
         """inner radius of the model shells"""
         if self._r_inner is None:
-            self._r_inner = self.mdl.tardis_config['structure']['r_inner']
+            self._r_inner = self.mdl.model.r_inner
         return self._r_inner
 
     @property
     def r_outer(self):
         """outer radius of the model shell"""
         if self._r_outer is None:
-            self._r_outer = self.mdl.tardis_config['structure']['r_outer']
+            self._r_outer = self.mdl.model.r_outer
         return self._r_outer
 
     @property
@@ -306,7 +306,8 @@ class opacity_calculator(object):
         """
 
         index = self.mdl.plasma.tau_sobolevs.index
-        line_waves = self.mdl.atom_data.lines.ix[index]
+        line_waves = \
+            self.mdl.plasma.atomic_data.lines.ix[index]
         line_waves = line_waves.wavelength.values * units.AA
 
         kappa_exp = np.zeros((self.nbins, self.nshells)) / units.cm


### PR DESCRIPTION
This PR fixes the kromer_plot and tardis_opacity scripts to work with the new indexing of the atomic lines data frame.