### PR TITLE
Make compatible with astropy 2.0

### DIFF
--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -6,7 +6,11 @@ import logging
 import numpy as np
 import astropy.units as units
 import astropy.constants as csts
-import astropy.analytic_functions as af
+try:
+    import astropy.modeling.blackbody as abb
+except ImportError:  # for astropy version < 2.0
+    import astropy.analytic_functions as abb
+
 import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.patches as patches
@@ -412,7 +416,7 @@ class tardis_kromer_plotter(object):
                 reti.set_facecolor(colors[i])
                 reti.set_edgecolor(colors[i])
                 reti.set_linewidth(0)
-                reti.xy[:, 1] *= Lnorm
+                reti.xy[:, 1] *= Lnorm.to('erg / s').value
 
         self.ax.plot(self.mdl.spectrum_wave,
                      self.mdl.spectrum_luminosity,
@@ -421,9 +425,9 @@ class tardis_kromer_plotter(object):
     def _generate_photosphere_part(self):
         """generate the photospheric input spectrum part of the Kromer plot"""
 
-        Lph = (af.blackbody_lambda(self.mdl.spectrum_wave, self.mdl.t_inner) *
+        Lph = (abb.blackbody_lambda(self.mdl.spectrum_wave, self.mdl.t_inner) *
                4 * np.pi**2 * self.mdl.R_phot**2 * units.sr).to(
-                   "erg / AA / s")
+                   "erg / (AA s)")
 
         self.ax.plot(self.mdl.spectrum_wave,
                      Lph, color="red", ls="dashed")
@@ -455,7 +459,7 @@ class tardis_kromer_plotter(object):
                 reti.set_facecolor(colors[i])
                 reti.set_edgecolor(colors[i])
                 reti.set_linewidth(0)
-                reti.xy[:, 1] *= Lnorm
+                reti.xy[:, 1] *= Lnorm.to('erg / s').value
 
     def _generate_and_add_colormap(self):
         """generate the custom color map, linking colours with atomic


### PR DESCRIPTION
This PR adds compatibility with astropy 2.0 while keeping backwards compatibility with astropy 1.3

Lnorm is converted from an astropy quantity to a scalar to prevent the error:
```
Traceback (most recent call last):
  File "../makekromerplot.py", line 19, in <module>
    fig = plotter.generate_plot(xlim=(3000,1e4), twinx=True)
  File "/Users/lshingles/Dropbox/GitHub/tardisanalysis/tardis_kromer_plot.py", line 369, in generate_plot
    self._generate_absorption_part()
  File "/Users/lshingles/Dropbox/GitHub/tardisanalysis/tardis_kromer_plot.py", line 458, in _generate_absorption_part
    reti.xy[:, 1] *= Lnorm
  File "/usr/local/lib/python2.7/site-packages/astropy/units/quantity.py", line 630, in __array_ufunc__
    out_array = check_output(out, unit, inputs, function=function)
  File "/usr/local/lib/python2.7/site-packages/astropy/units/quantity_helper.py", line 631, in check_output
    .format(function.__name__)))
astropy.units.core.UnitTypeError: Cannot store quantity with dimension resulting from multiply function in a non-Quantity instance.
```

If available, astropy.modeling.blackbody.blackbody_lambda is used instead of astropy.analytic_functions.blackbody_lambda to prevent the warning:
```
py.warnings - WARNING - /Users/lshingles/Dropbox/GitHub/tardisanalysis/tardis_kromer_plot.py:425: AstropyDeprecationWarning: The blackbody_lambda function is deprecated and may be removed in a future version.
        Use astropy.modeling.blackbody.blackbody_lambda instead.
```

The units "erg / AA / s" are changed to "erg / (AA s)" to prevent the warning:
```
[py.warnings         ][WARNING]  /usr/local/lib/python2.7/site-packages/astropy/units/format/generic.py:470: UnitsWarning: 'erg / AA / s' contains multiple slashes, which is discouraged by the FITS standard
  core.UnitsWarning)
```