### PR TITLE
Fixed an issue with tardis_line_id.py

### DIFF
--- a/tardis_line_id.py
+++ b/tardis_line_id.py
@@ -153,16 +153,22 @@ class line_identifier(object):
         else:
             self.lam_max = lam_max
 
-        if nlines == None:
-            self.nlines = 20
-        else:
-            self.nlines = nlines
-
         _lines_count = self.lines_count[np.argsort(self.lines_count)][::-1]
         _lines_fraction = self.lines_count[np.argsort(self.lines_count)][
             ::-1
         ] / float(self.lines_count.sum())
         _lines_ids = self.lines_ids_unique[np.argsort(self.lines_count)][::-1]
+
+        if nlines == None:
+            if len(_lines_count) > 20:
+                self.nlines = 20
+            else:
+                self.nlines = len(_lines_count)
+        else:
+            if len(_lines_count) > nlines:
+                self.nlines = nlines
+            else:
+                self.nlines = len(_lines_count)
 
         def ion2roman(ion_value):
             """function to convert ionisation level into roman numeral

--- a/tardis_line_id.py
+++ b/tardis_line_id.py
@@ -143,12 +143,12 @@ class line_identifier(object):
             tardis.__path__[0], "data", "atomic_symbols.dat"
         )
 
-        if lam_min == None:
+        if lam_min is None:
             self.lam_min = np.min(self.mdl.spectrum_wave).value
         else:
             self.lam_min = lam_min
 
-        if lam_max == None:
+        if lam_max is None:
             self.lam_max = np.max(self.mdl.spectrum_wave).value
         else:
             self.lam_max = lam_max
@@ -159,7 +159,7 @@ class line_identifier(object):
         ] / float(self.lines_count.sum())
         _lines_ids = self.lines_ids_unique[np.argsort(self.lines_count)][::-1]
 
-        if nlines == None:
+        if nlines is None:
             if len(_lines_count) > 20:
                 self.nlines = 20
             else:


### PR DESCRIPTION
There was a bug in tardis_line_id.py where the number of bars to include was set to 20, even if there were less than 20 transitions in the region of interest. This led to the program crashing. This has now been resolved.