### PR TITLE
Bug fixing in tardis_kromer_plot.py

### DIFF
--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -402,7 +402,6 @@ class tardis_kromer_plotter(object):
             self._elements_in_kromer_plot["atomic_no"],
             self._elements_in_kromer_plot["Total_no_of_interactions"],
         ]
-        print(self._elements_in_kromer_plot)
 
         if len(self._elements_in_kromer_plot) > self._nelements:
             self._elements_in_kromer_plot = self._elements_in_kromer_plot[


### PR DESCRIPTION
There is an issue with the current implementation of the xlim cuts applied to the plot.

The method of choosing which elements are included in the colour bar is currently based off the REST wavelength of the packet transitions. However, it is possible to have a feature present in the Kromer plot whose rest wavelength lies outside this range. This leads to elements not being included in the colour bar that should be.

The proposed fix calculates which packets lie inside the wavelength range based off their emitted or absorbed wavelengths, which is the correct method. This prevents the issue described above