### PR TITLE
Bug fixing in tardis_kromer_plot.py

### DIFF
--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -338,6 +338,8 @@ class tardis_kromer_plotter(object):
             units.Angstrom, equivalencies=units.spectral()
         )
 
+        print("test")
+
         self.last_line_interaction_in_id[
             "emitted_wavelength"
         ] = self.last_line_interaction_in_angstrom

--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -338,8 +338,6 @@ class tardis_kromer_plotter(object):
             units.Angstrom, equivalencies=units.spectral()
         )
 
-        print("test")
-
         self.last_line_interaction_in_id[
             "emitted_wavelength"
         ] = self.last_line_interaction_in_angstrom

--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -311,16 +311,6 @@ class tardis_kromer_plotter(object):
             units.Angstrom, equivalencies=units.spectral()
         )
 
-        self.lines = self.mdl.lines
-
-        packet_out_filter = (
-            self.last_line_interaction_out_angstrom
-            > self._xlim[0] * units.angstrom
-        ) & (
-            self.last_line_interaction_out_angstrom
-            < self._xlim[1] * units.angstrom
-        )
-
         self.last_line_interaction_out_id[
             "emitted_wavelength"
         ] = self.last_line_interaction_out_angstrom
@@ -346,16 +336,6 @@ class tardis_kromer_plotter(object):
         self.last_line_interaction_in_id = self.line_in_infos
         self.last_line_interaction_in_angstrom = self.line_in_nu.to(
             units.Angstrom, equivalencies=units.spectral()
-        )
-
-        self.lines = self.mdl.lines
-
-        packet_in_filter = (
-            self.last_line_interaction_in_angstrom
-            > self._xlim[0] * units.angstrom
-        ) & (
-            self.last_line_interaction_in_angstrom
-            < self._xlim[1] * units.angstrom
         )
 
         self.last_line_interaction_in_id[

--- a/tardis_kromer_plot.py
+++ b/tardis_kromer_plot.py
@@ -402,7 +402,6 @@ class tardis_kromer_plotter(object):
             self._elements_in_kromer_plot["atomic_no"],
             self._elements_in_kromer_plot["Total_no_of_interactions"],
         ]
-        print(self._elements_in_kromer_plot)
 
         if len(self._elements_in_kromer_plot) > self._nelements:
             self._elements_in_kromer_plot = self._elements_in_kromer_plot[


### PR DESCRIPTION
Same as #36 but from my forked repo instead

There is an issue with the current implementation of the xlim cuts applied to the plot.

The method of choosing which elements are included in the colour bar is currently based off the REST wavelength of the packet transitions. However, it is possible to have a feature present in the Kromer plot whose rest wavelength lies outside this range. This leads to elements not being included in the colour bar that should be.

The proposed fix calculates which packets lie inside the wavelength range based off their emitted or absorbed wavelengths, which is the correct method. This prevents the issue described above